### PR TITLE
Add 'pathname' type and a 'prefix' property

### DIFF
--- a/command.js
+++ b/command.js
@@ -109,12 +109,12 @@ function insertFileHeaderGuard() {
             separator = "\\";
         }
         var currentPathName = _editor.document.fileName.replace(_root, "");
-        var stop_tokens = _workspace.getConfiguration("headFileGuard").get("path_stop_tokens",["src","include"]);
+        var stop_dirs = _workspace.getConfiguration("headFileGuard").get("path_stop_dirs",["src","include"]);
         var stop = 0;
-        for (var i = 0; i < stop_tokens.length; i++) {
-            var token = stop_tokens[i];
-            if (token != undefined) {
-                var next_stop = currentPathName.lastIndexOf(separator + token + separator) + token.length + 2;
+        for (var i = 0; i < stop_dirs.length; i++) {
+            var dir = stop_dirs[i];
+            if (dir != undefined) {
+                var next_stop = currentPathName.lastIndexOf(separator + dir + separator) + dir.length + 2;
                 if (next_stop > stop) {
                     stop = next_stop;
                 }

--- a/command.js
+++ b/command.js
@@ -101,7 +101,7 @@ function insertFileHeaderGuard() {
             separator = "\\";
         }
         var currentFileName = _editor.document.fileName.substr(_editor.document.fileName.lastIndexOf(separator) + 1);
-        guardName = currentFileName.replace(".", "_").toUpperCase();
+        guardName = currentFileName.replace(/\./g, "_").toUpperCase();
     } else if (guardType === "pathname") {
         console.log("file: " + _editor.document.fileName);
         var separator = "/";

--- a/command.js
+++ b/command.js
@@ -102,9 +102,36 @@ function insertFileHeaderGuard() {
         }
         var currentFileName = _editor.document.fileName.substr(_editor.document.fileName.lastIndexOf(separator) + 1);
         guardName = currentFileName.replace(".", "_").toUpperCase();
+    } else if (guardType === "pathname") {
+        console.log("file: " + _editor.document.fileName);
+        var separator = "/";
+        if (process.platform === "win32") {
+            separator = "\\";
+        }
+        var currentPathName = _editor.document.fileName.replace(_root, "");
+        var stop_tokens = _workspace.getConfiguration("headFileGuard").get("path_stop_tokens",["src","include"]);
+        var stop = 0;
+        for (var i = 0; i < stop_tokens.length; i++) {
+            var token = stop_tokens[i];
+            if (token != undefined) {
+                var next_stop = currentPathName.lastIndexOf(separator + token + separator) + token.length + 2;
+                if (next_stop > stop) {
+                    stop = next_stop;
+                }
+            }
+        }
+        currentPathName = currentPathName.substr(stop);
+        while (currentPathName.indexOf(separator) == 0) {
+            currentPathName = currentPathName.substr(1);
+        }
+        console.log("pathname: '" + currentPathName + "'");
+        guardName = currentPathName.replace(/\./g, "_").replace(new RegExp(separator, "g"), "__").toUpperCase();
     } else {
         guardName = new GUID().newGUID().toUpperCase();
     }
+
+    var prefix = _workspace.getConfiguration("headFileGuard").get("prefix", "");
+    guardName = prefix + guardName;
 
     var guardStartFormat = "#ifndef {guard}\n#define {guard}\n";
     var guardEndFormat = "\n#endif /* {guard} */\n";

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-    "name": "head-file-guard",
-    "displayName": "Head-File-Guard",
-    "description": "add head-file-guard in c/c++ head-file",
-    "version": "0.0.2",
-    "publisher": "bjr",
-    "license": "MIT",
-    "author": {
+	"name": "head-file-guard",
+	"displayName": "Head-File-Guard",
+	"description": "add head-file-guard in c/c++ head-file",
+	"version": "0.0.2",
+	"publisher": "bjr",
+	"license": "MIT",
+	"author": {
 		"email": "bjrxyz@sina.com",
 		"name": "Bo Jing Ren",
 		"url": "https://bjrxyz.github.io/"
@@ -18,41 +18,66 @@
 		"url": "hhttps://github.com/bjrxyz/vscode-head-file-guard/issues",
 		"email": "bjrxyz@sina.com"
 	},
-    "engines": {
-        "vscode": "^1.0.0"
-    },
-    "categories": [
-        "Other"
-    ],
-    "activationEvents": [
-        "onCommand:extension.headFileGuard.insertHeadFileGuard"
-    ],
-    "main": "./extension",
-    "contributes": {
-        "commands": [{
-            "command": "extension.headFileGuard.insertHeadFileGuard",
-            "title": "Insert Head-File-Guard"
-        }],
-        "configuration": {
+	"engines": {
+		"vscode": "^1.0.0"
+	},
+	"categories": [
+		"Other"
+	],
+	"activationEvents": [
+		"onCommand:extension.headFileGuard.insertHeadFileGuard"
+	],
+	"main": "./extension",
+	"contributes": {
+		"commands": [
+			{
+				"command": "extension.headFileGuard.insertHeadFileGuard",
+				"title": "Insert Head-File-Guard"
+			}
+		],
+		"configuration": {
 			"title": "Head-File-Guard extension configuration",
 			"type": "object",
 			"properties": {
 				"headFileGuard.type": {
 					"title": "Header-File-Guard settings",
 					"type": [
-								"string"
-							],
+						"string"
+					],
 					"default": "filename",
-					"description": "This properties instructed how to generate the headFileGuard,filename or guid "
-					
+					"description": "This properties instructed how to generate the headFileGuard, filename, pathname or guid "
+				},
+				"headFileGuard.path_stop_tokens": {
+					"title": "Header-File-Guard settings",
+					"type": [
+						"array"
+					],
+					"default": [
+						"src",
+						"include"
+					],
+					"description": "This property controls which path components will signal the beginning of the considered pathname--the last occurrence of any of these tokens signals the start of the considered path; if empty, then workspace root will be used"
+				},
+				"headFileGuard.prefix": {
+					"title": "Header-File-Guard settings",
+					"type": [
+						"string"
+					],
+					"default": "",
+					"description": "This property allows a custom prefix to be added to all generated header guard names"
 				}
 			}
 		}
-    },
-    "scripts": {
-        "postinstall": "node ./node_modules/vscode/bin/install"
-    },
-    "devDependencies": {
-        "vscode": "^0.11.0"
-    }
+	},
+	"scripts": {
+		"postinstall": "node ./node_modules/vscode/bin/install"
+	},
+	"devDependencies": {
+		"vscode": "^0.11.0"
+	},
+	"__metadata": {
+		"id": "2f439332-23cb-4928-bd82-577a9ea0fddf",
+		"publisherDisplayName": "bjr",
+		"publisherId": "feec67a9-51aa-416d-b324-b4a82ab0b57a"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 					"default": "filename",
 					"description": "This properties instructed how to generate the headFileGuard, filename, pathname or guid "
 				},
-				"headFileGuard.path_stop_tokens": {
+				"headFileGuard.path_stop_dirs": {
 					"title": "Header-File-Guard settings",
 					"type": [
 						"array"
@@ -56,7 +56,7 @@
 						"src",
 						"include"
 					],
-					"description": "This property controls which path components will signal the beginning of the considered pathname--the last occurrence of any of these tokens signals the start of the considered path; if empty, then workspace root will be used"
+					"description": "This property controls which dirs in the path will signal the beginning of the considered pathname--the last occurrence of any of these dirs signals the start of the considered path; if empty, then workspace root will be used"
 				},
 				"headFileGuard.prefix": {
 					"title": "Header-File-Guard settings",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "head-file-guard",
 	"displayName": "Head-File-Guard",
 	"description": "add head-file-guard in c/c++ head-file",
-	"version": "0.0.2",
+	"version": "0.0.3",
 	"publisher": "bjr",
 	"license": "MIT",
 	"author": {


### PR DESCRIPTION
1. This adds a new `type` choice: `pathname` which uses the property `path_stop_dirs` (array with default of `["src", "include"]`) which will consider the full path of the current file (up to the first occurrence of one of those dirs) when creating the include guard.
For example, the file: `my/workspace/root/project/src/foo/bar/baz.hpp` would generate the header guard name of `FOO__BAR__BAZ_HPP`.

1. Also adds the `prefix` property which is added at the beginning of any generated include guards.

1. Includes a fix for #3, and the `prefix` could be used to solve #2 