### PR TITLE
Prevent illegal macro names being generated

### DIFF
--- a/command.js
+++ b/command.js
@@ -125,7 +125,7 @@ function insertFileHeaderGuard() {
             currentPathName = currentPathName.substr(1);
         }
         console.log("pathname: '" + currentPathName + "'");
-        guardName = currentPathName.replace(/\./g, "_").replace(new RegExp(separator, "g"), "__").toUpperCase();
+        guardName = currentPathName.replace(/[^0-9A-Za-z_]/g, "_").replace(new RegExp(separator, "g"), "__").toUpperCase();
     } else {
         guardName = new GUID().newGUID().toUpperCase();
     }


### PR DESCRIPTION
Source filenames can contain characters illegal in C/C++ identifiers. Prevent illegal macro names being generated by replacing all characters not allowed in an identifier with underscores.